### PR TITLE
The parent folder name shall not appear in the path

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,10 +1,10 @@
 {
   "name": "Battery",
   "description": "Battery provides a good template for an in-app battery/charge indicator with different visualization choices, plus ideas of what could be changed once battery level gets low.",
-  "appcache_path": "battery.appcache",
-  "launch_path": "index.html",
+  "appcache_path": "/battery.appcache",
+  "launch_path": "/index.html",
   "icons": {
-    "128": "images/icon-128.png"
+    "128": "/images/icon-128.png"
   },
   "developer": {
     "name": "Chris Mills",


### PR DESCRIPTION
Otherwise the app manager will fail to install the applicaiton due to not able to find the index.html. Since the parent folder will appear twice in the path. 
